### PR TITLE
Fix spinlock assembly constraint

### DIFF
--- a/inc/x86_64/spinlock.hpp
+++ b/inc/x86_64/spinlock.hpp
@@ -48,6 +48,6 @@ class Spinlock
         ALWAYS_INLINE
         inline void unlock()
         {
-            asm volatile ("incb %0" : "=m" (val) : : "memory");
+            asm volatile ("incb %0" : "+m" (val) : : "memory");
         }
 };


### PR DESCRIPTION
As val is also read in the Spinlock::unlock function, it must have a "+" (update) constraint.